### PR TITLE
Always log and change bindings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,14 @@ export default function knexTinyLogger (knex, { logger = console.log } = {}) {
     queries[queryId] = { sql, bindings, startTime }
   })
   .on('query-error', (_error, { __knexQueryUid: queryId }) => {
-    delete queries[queryId]
+    logQuery(queryId, 'red')
   })
   .on('query-response', (response, { __knexQueryUid: queryId }) => {
+    logQuery(queryId)
+  })
+  return knex
+
+  function logQuery (queryId, sqlOutputColor = 'cyan') {
     const { sql, bindings, startTime } = queries[queryId]
     delete queries[queryId]
 
@@ -27,10 +32,9 @@ export default function knexTinyLogger (knex, { logger = console.log } = {}) {
 
     logger('%s %s',
       chalk.magenta(`SQL (${duration.toFixed(3)} ms)`),
-      chalk.cyan(sqlRequest)
+      chalk[sqlOutputColor](sqlRequest)
     )
-  })
-  return knex
+  }
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -46,10 +46,12 @@ export default function knexTinyLogger (knex, { logger = console.log } = {}) {
  */
 
 function insertBindingsToSQL (sql, bindings) {
-  return sql.split('?').reduce((memo, part, index) => {
-    const binding = bindings[index] ? JSON.stringify(bindings[index]) : ''
-    return memo + part + binding
-  }, '')
+  return sql.replace(/\$\d+/g, replacer)
+
+  function replacer (match) {
+    const position = parseInt(match.replace('$', ''), 10)
+    return bindings[position - 1] ? JSON.stringify(bindings[position - 1]) : match
+  }
 }
 
 /**


### PR DESCRIPTION
This PR changes how the logger handles errors - it will always output the SQL. Previously it muted those SQL. Now it will highlight them in red.
It also fixes binding replacement in the SQL statement. The old version used `?` but this one uses `$1, $2`, etc...

Working example of binding replacement can be seen here https://repl.it/repls/GainsboroGlaringAmazontreeboa