### PR TITLE
Fix query-executioner usage

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -96,7 +96,7 @@ function getKnexFormatQuery(knex: Knex): KnexTinyLogger$KnexFormatQuery {
     return (sql, bindings) => knex.client._formatQuery(sql, bindings)
   } else if ((queryExecutionerFormat = resolveQueryExecutionerFormat()) != null) {
     // $FlowExpectError
-    return (sql, bindings) => queryExecutionerFormat(sql, bindings, undefined, knex)
+    return (sql, bindings) => queryExecutionerFormat(sql, bindings, undefined, knex.client)
   } else {
     return (sql) => sql
   }


### PR DESCRIPTION
Knex at >0.95.0 is not working properly due to query-executioner expecting knex.client instead of whole knex instance
This should fix it