### PR TITLE
parse sql and show bindings, closes #11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ function printWithBindings(sql: string, bindings: (string | number)[]) {
   return sql
     .replace(/\$\d{1,2}/g, () => {
       const variable = bindings[index++]
-      if (typeof variable === 'number') {
+      if (typeof variable === 'number' || typeof variable === 'boolean') {
         return String(variable)
       }
       return `'${variable}'`

--- a/src/index.js
+++ b/src/index.js
@@ -73,13 +73,13 @@ function makeQueryPrinter(knex: Knex, { logger, withBindings }) {
   const formatQuery = getKnexFormatQuery(knex)
 
   return function print({ sql, bindings, duration }, colorize: Function) {
-    const sqlRequest = withBindings ? formatQuery(sql, null) : printWithBindings(sql, bindings)
+    const sqlRequest = withBindings ? formatWithBindings(sql, bindings) : formatQuery(sql, null)
 
     logger('%s %s', COLORIZE.primary(`SQL (${duration.toFixed(3)} ms)`), colorize(sqlRequest))
   }
 }
 
-function printWithBindings(sql: string, bindings: (string | number)[]) {
+function formatWithBindings(sql: string, bindings: (string | number)[]) {
   let index = 0
   return sql
     .replace(/\$\d{1,2}/g, () => {

--- a/src/index.js
+++ b/src/index.js
@@ -73,10 +73,22 @@ function makeQueryPrinter(knex: Knex, { logger, withBindings }) {
   const formatQuery = getKnexFormatQuery(knex)
 
   return function print({ sql, bindings, duration }, colorize: Function) {
-    const sqlRequest = formatQuery(sql, withBindings ? bindings : null)
+    const sqlRequest = withBindings ? formatQuery(sql, null) : printWithBindings(sql, bindings)
 
     logger('%s %s', COLORIZE.primary(`SQL (${duration.toFixed(3)} ms)`), colorize(sqlRequest))
   }
+}
+
+function printWithBindings(sql: string, bindings: (string | number)[]) {
+  let index = 0
+  return sql
+    .replace(/\$\d{1,2}/g, () => {
+      const variable = bindings[index++]
+      if (typeof variable === 'number') {
+        return String(variable)
+      }
+      return `'${variable}'`
+    })
 }
 
 function measureStartTime() {


### PR DESCRIPTION
This PR is the replacement of #17 , I've confirmed bindings are shown to the console.

![image](https://user-images.githubusercontent.com/10719495/122752851-68e60b00-d2cc-11eb-8f6c-02f8ec03c68e.png)
