### PR TITLE
feat: syntax-highlight colorful logs via a highlight flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,12 @@ knexTinyLogger(knex, {
 
 ## Colorful Logs
 
-The colorful logger is the same string logger experience, with output colored by query state.
-It supports the same `bindings`, `formatter`, and `write` options as `defaultLogger`.
+The colorful logger is the same string logger experience, with output colored by query
+state. It supports the same `bindings`, `formatter`, and `write` options as `defaultLogger`,
+and has no extra runtime dependencies.
 
-Successful SQL is cyan; failed SQL is red. The message shape otherwise matches `defaultLogger`.
+By default the whole message is colored by state: the `SQL` / `SQL ERROR` label and the SQL
+body are cyan for successful queries and red for failed ones.
 
 ```ts
 import knexTinyLogger from 'knex-tiny-logger'
@@ -107,6 +109,50 @@ import { colorfulLogger } from 'knex-tiny-logger/colorful'
 
 knexTinyLogger(knex, {
   logger: colorfulLogger(),
+})
+```
+
+### Syntax highlighting
+
+Set `highlight: true` to syntax-highlight the SQL body instead. The label still carries the
+query state (cyan or red); the body's tokens are colored by an ANSI theme. `formatter`, when
+provided, controls the SQL string before highlighting is applied.
+
+```ts
+import { colorfulLogger, colorfulSyntaxThemes } from 'knex-tiny-logger/colorful'
+
+knexTinyLogger(knex, {
+  logger: colorfulLogger({ highlight: true, theme: colorfulSyntaxThemes.dracula }),
+})
+```
+
+`colorfulSyntaxThemes.default` is a 16-color ANSI theme: it adapts to your terminal's
+palette and is used when no theme is given. The named themes are fixed 24-bit truecolor
+(they need a truecolor-capable terminal) — dark: `dracula`, `nord`, `monokai`, `oneDark`,
+`solarizedDark`, `tokyoNight`, `catppuccinMocha`; light: `solarizedLight`, `githubLight`,
+`oneLight`, `catppuccinLatte`. Extend a theme to override token colors with raw ANSI
+strings, or use `false` to disable a token color:
+
+```ts
+knexTinyLogger(knex, {
+  logger: colorfulLogger({
+    highlight: true,
+    theme: colorfulSyntaxThemes.dracula.extend({
+      keyword: false,
+      fn: '\x1b[31m',
+    }),
+  }),
+})
+```
+
+You can also reuse the same syntax coloring in custom formatters:
+
+```ts
+import { defaultQueryFormatter } from 'knex-tiny-logger'
+import { colorfulSyntaxFormatter, colorfulSyntaxThemes } from 'knex-tiny-logger/colorful'
+
+const formatter = colorfulSyntaxFormatter(defaultQueryFormatter(), {
+  theme: colorfulSyntaxThemes.solarizedLight,
 })
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -23,7 +23,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   }
 }

--- a/examples/sqlite-colorful.mjs
+++ b/examples/sqlite-colorful.mjs
@@ -1,0 +1,39 @@
+import createKnex from 'knex'
+import knexTinyLogger from 'knex-tiny-logger'
+import { colorfulLogger, colorfulSyntaxThemes } from 'knex-tiny-logger/colorful'
+
+const knex = knexTinyLogger(
+  createKnex({
+    client: 'sqlite3',
+    connection: {
+      filename: ':memory:',
+    },
+    useNullAsDefault: true,
+  }),
+  {
+    // Syntax-highlight the SQL body; drop the options for plain state-tinted output.
+    logger: colorfulLogger({ highlight: true, theme: colorfulSyntaxThemes.dracula }),
+  },
+)
+
+await knex.schema.createTable('users', (table) => {
+  table.increments('id')
+  table.string('name').notNullable()
+  table.integer('age').notNullable()
+})
+
+await knex('users').insert([
+  { name: 'Ada', age: 37 },
+  { name: 'Grace', age: 85 },
+])
+
+await knex('users').where('age', '>', 40).select('id', 'name', 'age')
+await knex('users').count({ total: '*' })
+
+try {
+  await knex.raw('select * from missing_table where id = ?', [1])
+} catch {
+  // Keep the example focused on logger output.
+}
+
+await knex.destroy()

--- a/src/ansi.ts
+++ b/src/ansi.ts
@@ -1,9 +1,6 @@
 const RESET = '\u001B[39m'
 
 export const ansi = {
-  magenta(message: string): string {
-    return `\u001B[35m${message}${RESET}`
-  },
   red(message: string): string {
     return `\u001B[31m${message}${RESET}`
   },

--- a/src/colorful-logger.test.ts
+++ b/src/colorful-logger.test.ts
@@ -2,9 +2,12 @@ import assert from 'node:assert/strict'
 import test from 'node:test'
 import { createQueryEndEvent, createQueryErrorEvent } from '../test/helpers/events.ts'
 import { colorfulLogger } from './colorful-logger.ts'
+import { colorfulSyntaxThemes } from './colorful-syntax.ts'
 import type { QueryFormatterInput } from './types.ts'
 
-test('colorfulLogger writes successful queries', () => {
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g')
+
+test('colorfulLogger tints successful queries by state', () => {
   const calls: string[] = []
   const logger = colorfulLogger({
     write(message) {
@@ -15,13 +18,11 @@ test('colorfulLogger writes successful queries', () => {
   logger.onEnd?.(createQueryEndEvent())
 
   assert.equal(calls.length, 1)
-  assert.match(calls[0], /SQL \(12\.346 ms\)/)
-  assert.match(calls[0], /select \? -- \[1\]/)
-  assert.equal(calls[0]?.includes('\u001B[35m'), true)
-  assert.equal(calls[0]?.includes('\u001B[36m'), true)
+  assert.equal(calls[0]?.includes('\x1b[36mSQL (12.346 ms)\x1b[39m'), true)
+  assert.equal(calls[0]?.includes('\x1b[36mselect ? -- [1]\x1b[39m'), true)
 })
 
-test('colorfulLogger writes failed queries', () => {
+test('colorfulLogger tints failed queries by state', () => {
   const calls: string[] = []
   const logger = colorfulLogger({
     write(message) {
@@ -32,10 +33,8 @@ test('colorfulLogger writes failed queries', () => {
   logger.onError?.(createQueryErrorEvent({ sql: 'select broken', bindings: [] }))
 
   assert.equal(calls.length, 1)
-  assert.match(calls[0], /SQL \(12\.346 ms\)/)
-  assert.match(calls[0], /select broken/)
-  assert.equal(calls[0]?.includes('\u001B[35m'), true)
-  assert.equal(calls[0]?.includes('\u001B[31m'), true)
+  assert.equal(calls[0]?.includes('\x1b[31mSQL ERROR (12.346 ms)\x1b[39m'), true)
+  assert.equal(calls[0]?.includes('\x1b[31mselect broken\x1b[39m'), true)
 })
 
 test('colorfulLogger supports custom formatters', () => {
@@ -53,6 +52,116 @@ test('colorfulLogger supports custom formatters', () => {
 
   assert.equal(calls.length, 1)
   assert.match(calls[0], /select \? -- custom/)
+})
+
+test('colorfulLogger highlights the SQL body in highlight mode', () => {
+  const calls: string[] = []
+  const logger = colorfulLogger({
+    highlight: true,
+    write(message) {
+      calls.push(message)
+    },
+  })
+
+  logger.onEnd?.(
+    createQueryEndEvent({ sql: "select count(*) from users where id = 12 and name = 'Ada'", bindings: [] }),
+  )
+
+  assert.equal(calls.length, 1)
+  // Label carries the query state; the body is syntax-highlighted, not tinted as one span.
+  assert.equal(calls[0]?.includes('\x1b[36mSQL (12.346 ms)\x1b[39m'), true)
+  assert.equal(calls[0]?.includes('\x1b[0m'), true)
+  assert.equal(stripAnsi(calls[0] ?? ''), "SQL (12.346 ms) select count(*) from users where id = 12 and name = 'Ada'")
+})
+
+test('colorfulLogger highlights failed queries', () => {
+  const calls: string[] = []
+  const logger = colorfulLogger({
+    highlight: true,
+    write(message) {
+      calls.push(message)
+    },
+  })
+
+  logger.onError?.(createQueryErrorEvent({ sql: 'select broken', bindings: [] }))
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0]?.includes('\x1b[31mSQL ERROR (12.346 ms)\x1b[39m'), true)
+  assert.equal(stripAnsi(calls[0] ?? ''), 'SQL ERROR (12.346 ms) select broken')
+})
+
+test('colorfulLogger highlights with extended themes', () => {
+  const calls: string[] = []
+  const logger = colorfulLogger({
+    highlight: true,
+    theme: colorfulSyntaxThemes.default.extend({
+      keyword: '<k>',
+      fn: '<f>',
+      clear: '</>',
+    }),
+    formatter() {
+      return 'select max(age) from users'
+    },
+    write(message) {
+      calls.push(message)
+    },
+  })
+
+  logger.onEnd?.(createQueryEndEvent())
+
+  assert.equal(calls[0]?.includes('<k>select</>'), true)
+  assert.equal(calls[0]?.includes('<f>max</>'), true)
+})
+
+test('colorfulLogger highlights with bindings false', () => {
+  const calls: string[] = []
+  const logger = colorfulLogger({
+    highlight: true,
+    bindings: false,
+    write(message) {
+      calls.push(message)
+    },
+  })
+
+  logger.onEnd?.(createQueryEndEvent({ sql: 'select ?', bindings: [1] }))
+
+  assert.equal(stripAnsi(calls[0] ?? ''), 'SQL (12.346 ms) select ?')
+})
+
+test('colorfulLogger highlights custom formatter output', () => {
+  const calls: string[] = []
+  const logger = colorfulLogger({
+    highlight: true,
+    formatter(event) {
+      return `${event.sql} -- custom`
+    },
+    write(message) {
+      calls.push(message)
+    },
+  })
+
+  logger.onEnd?.(createQueryEndEvent())
+
+  assert.equal(stripAnsi(calls[0] ?? ''), 'SQL (12.346 ms) select ? -- custom')
+  assert.equal(calls[0]?.includes('\x1b[0m'), true)
+})
+
+test('colorfulLogger highlights with a truecolor theme', () => {
+  const calls: string[] = []
+  const logger = colorfulLogger({
+    highlight: true,
+    theme: colorfulSyntaxThemes.solarizedLight,
+    formatter() {
+      return 'select 1'
+    },
+    write(message) {
+      calls.push(message)
+    },
+  })
+
+  logger.onEnd?.(createQueryEndEvent())
+
+  assert.equal(stripAnsi(calls[0] ?? ''), 'SQL (12.346 ms) select 1')
 })
 
 test('colorfulLogger warns when bindings and formatter are provided together', () => {
@@ -76,3 +185,46 @@ test('colorfulLogger warns when bindings and formatter are provided together', (
 
   assert.deepEqual(warnings, [['knex-tiny-logger: "bindings" is ignored when "formatter" is provided.']])
 })
+
+test('colorfulLogger warns when theme is provided without highlight', () => {
+  const warnings: unknown[][] = []
+  const originalWarn = console.warn
+
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args)
+  }
+
+  try {
+    colorfulLogger({ theme: colorfulSyntaxThemes.dracula } as unknown as Parameters<typeof colorfulLogger>[0])
+  } finally {
+    console.warn = originalWarn
+  }
+
+  assert.deepEqual(warnings, [['knex-tiny-logger: "theme" is ignored unless "highlight" is enabled.']])
+})
+
+test('colorfulLogger ignores theme without highlight and tints instead', () => {
+  const calls: string[] = []
+  const originalWarn = console.warn
+  console.warn = () => {}
+
+  try {
+    const logger = colorfulLogger({
+      theme: colorfulSyntaxThemes.dracula,
+      write(message: string) {
+        calls.push(message)
+      },
+    } as unknown as Parameters<typeof colorfulLogger>[0])
+    logger.onEnd?.(createQueryEndEvent({ sql: 'select 1', bindings: [] }))
+  } finally {
+    console.warn = originalWarn
+  }
+
+  // Tinted as one span (no per-token clear), not syntax-highlighted.
+  assert.equal(calls[0]?.includes('\x1b[36mselect 1\x1b[39m'), true)
+  assert.equal(calls[0]?.includes('\x1b[0m'), false)
+})
+
+function stripAnsi(message: string): string {
+  return message.replace(ANSI_PATTERN, '')
+}

--- a/src/colorful-logger.ts
+++ b/src/colorful-logger.ts
@@ -1,18 +1,46 @@
 import { ansi } from './ansi.ts'
-import { defaultQueryFormatter } from './formatter.ts'
+import type { ColorfulSyntaxThemeInput } from './colorful-syntax.ts'
+import { colorfulSyntaxFormatter } from './colorful-syntax.ts'
 import { resolveMessageWriter } from './message-writer.ts'
-import type { ColorfulLoggerOptions, Logger, QueryFormatter } from './types.ts'
+import { resolveStringFormatter } from './resolve-formatter.ts'
+import type { Logger, QueryFormatter, StringLoggerOptions } from './types.ts'
 
-const COLORIZE = {
-  primary: ansi.magenta,
-  error: ansi.red,
-  success: ansi.cyan,
-}
+/**
+ * Options accepted by `colorfulLogger`.
+ *
+ * Same formatting options as `defaultLogger`, plus optional syntax highlighting.
+ */
+export type ColorfulLoggerOptions = StringLoggerOptions &
+  (
+    | {
+        /**
+         * Syntax-highlight the SQL body instead of tinting the whole line by state.
+         *
+         * Defaults to `false`.
+         */
+        highlight?: false
+        theme?: never
+      }
+    | {
+        highlight: true
+        /**
+         * SQL syntax color theme. Applies only in highlight mode.
+         *
+         * Defaults to `colorfulSyntaxThemes.default`.
+         */
+        theme?: ColorfulSyntaxThemeInput
+      }
+  )
 
 /**
  * Create the built-in ANSI-colored string logger.
  *
- * It behaves like `defaultLogger`, but colors output by query state.
+ * It behaves like `defaultLogger`, but colors output by query state: the
+ * `SQL` / `SQL ERROR` label is cyan for successful queries and red for failed
+ * ones. By default the SQL body shares that state color.
+ *
+ * Set `highlight: true` to syntax-highlight the SQL body instead; the label
+ * keeps carrying the query state. Pass `theme` to pick the syntax colors.
  *
  * It writes to `console.log` by default.
  *
@@ -24,35 +52,49 @@ const COLORIZE = {
  * @example
  * ```ts
  * import knexTinyLogger from 'knex-tiny-logger'
- * import { colorfulLogger } from 'knex-tiny-logger/colorful'
+ * import { colorfulLogger, colorfulSyntaxThemes } from 'knex-tiny-logger/colorful'
  *
  * knexTinyLogger(knex, {
  *   logger: colorfulLogger(),
+ * })
+ *
+ * knexTinyLogger(knex, {
+ *   logger: colorfulLogger({ highlight: true, theme: colorfulSyntaxThemes.dracula }),
  * })
  * ```
  */
 export function colorfulLogger(options: ColorfulLoggerOptions = {}): Logger {
   const write = resolveMessageWriter(options.write)
-  const formatter = resolveFormatter(options)
+  const format = resolveStringFormatter(options)
+  const renderBody = resolveBodyRenderer(options, format)
 
   return {
     onEnd(event) {
-      write(`${COLORIZE.primary(`SQL (${event.durationMs.toFixed(3)} ms)`)} ${COLORIZE.success(formatter(event))}`)
+      write(`${ansi.cyan(`SQL (${event.durationMs.toFixed(3)} ms)`)} ${renderBody.success(event)}`)
     },
     onError(event) {
-      write(`${COLORIZE.primary(`SQL (${event.durationMs.toFixed(3)} ms)`)} ${COLORIZE.error(formatter(event))}`)
+      write(`${ansi.red(`SQL ERROR (${event.durationMs.toFixed(3)} ms)`)} ${renderBody.error(event)}`)
     },
   }
 }
 
-function resolveFormatter(options: ColorfulLoggerOptions): QueryFormatter {
-  if (options.formatter) {
-    if ('bindings' in options) {
-      console.warn('knex-tiny-logger: "bindings" is ignored when "formatter" is provided.')
-    }
+interface BodyRenderer {
+  success: QueryFormatter
+  error: QueryFormatter
+}
 
-    return options.formatter
+function resolveBodyRenderer(options: ColorfulLoggerOptions, format: QueryFormatter): BodyRenderer {
+  if (options.highlight) {
+    const highlight = colorfulSyntaxFormatter(format, { theme: options.theme })
+    return { success: highlight, error: highlight }
   }
 
-  return defaultQueryFormatter({ bindings: options.bindings })
+  if (options.theme != null) {
+    console.warn('knex-tiny-logger: "theme" is ignored unless "highlight" is enabled.')
+  }
+
+  return {
+    success: (event) => ansi.cyan(format(event)),
+    error: (event) => ansi.red(format(event)),
+  }
 }

--- a/src/colorful-syntax-highlight.ts
+++ b/src/colorful-syntax-highlight.ts
@@ -1,0 +1,268 @@
+import type { ColorfulSyntaxColor, ColorfulSyntaxTheme } from './colorful-syntax.ts'
+
+const KEYWORDS = /* @__PURE__ */ new Set([
+  'add',
+  'all',
+  'alter',
+  'and',
+  'as',
+  'asc',
+  'between',
+  'by',
+  'case',
+  'check',
+  'column',
+  'constraint',
+  'create',
+  'cross',
+  'database',
+  'default',
+  'delete',
+  'desc',
+  'distinct',
+  'drop',
+  'else',
+  'end',
+  'except',
+  'exists',
+  'false',
+  'for',
+  'foreign',
+  'from',
+  'full',
+  'group',
+  'having',
+  'in',
+  'index',
+  'inner',
+  'insert',
+  'intersect',
+  'into',
+  'is',
+  'join',
+  'key',
+  'left',
+  'like',
+  'limit',
+  'not',
+  'null',
+  'offset',
+  'on',
+  'or',
+  'order',
+  'outer',
+  'primary',
+  'references',
+  'returning',
+  'right',
+  'select',
+  'set',
+  'table',
+  'then',
+  'true',
+  'union',
+  'unique',
+  'update',
+  'using',
+  'values',
+  'when',
+  'where',
+  'with',
+])
+
+/**
+ * Tokenize a SQL string and color the recognized tokens (keywords, functions,
+ * numbers, strings, comments, brackets, special chars) with the theme's ANSI
+ * colors. Other identifiers pass through uncolored.
+ */
+export function highlightSql(sql: string, colors: ColorfulSyntaxTheme): string {
+  let result = ''
+  let index = 0
+
+  while (index < sql.length) {
+    const char = sql[index]
+    const next = sql[index + 1]
+
+    if (isWhitespace(char)) {
+      result += char
+      index += 1
+      continue
+    }
+
+    if (char === '-' && next === '-') {
+      const end = findLineCommentEnd(sql, index + 2)
+      result += colorize(sql.slice(index, end), colors.comment, colors.clear)
+      index = end
+      continue
+    }
+
+    if (char === '/' && next === '*') {
+      const end = findBlockCommentEnd(sql, index + 2)
+      result += colorize(sql.slice(index, end), colors.comment, colors.clear)
+      index = end
+      continue
+    }
+
+    if (char === "'" || char === '"') {
+      const end = findStringEnd(sql, index + 1, char)
+      result += colorize(sql.slice(index, end), colors.string, colors.clear)
+      index = end
+      continue
+    }
+
+    if (isNumberStart(sql, index)) {
+      const end = findNumberEnd(sql, index)
+      result += colorize(sql.slice(index, end), colors.number, colors.clear)
+      index = end
+      continue
+    }
+
+    if (isIdentifierStart(char)) {
+      const end = findIdentifierEnd(sql, index + 1)
+      const word = sql.slice(index, end)
+      const lowerWord = word.toLowerCase()
+
+      if (KEYWORDS.has(lowerWord)) {
+        result += colorize(word, colors.keyword, colors.clear)
+      } else if (isFunctionCall(sql, end)) {
+        result += colorize(word, colors.fn, colors.clear)
+      } else {
+        result += word
+      }
+
+      index = end
+      continue
+    }
+
+    if (char === '(' || char === ')') {
+      result += colorize(char, colors.bracket, colors.clear)
+      index += 1
+      continue
+    }
+
+    result += colorize(char, colors.special, colors.clear)
+    index += 1
+  }
+
+  return result
+}
+
+function colorize(token: string, color: ColorfulSyntaxColor, clear: string): string {
+  if (color === false) {
+    return token
+  }
+
+  return `${color}${token}${clear}`
+}
+
+function isWhitespace(char: string | undefined): boolean {
+  return char === ' ' || char === '\n' || char === '\r' || char === '\t'
+}
+
+function findLineCommentEnd(sql: string, index: number): number {
+  while (index < sql.length && sql[index] !== '\n' && sql[index] !== '\r') {
+    index += 1
+  }
+
+  return index
+}
+
+function findBlockCommentEnd(sql: string, index: number): number {
+  const end = sql.indexOf('*/', index)
+
+  return end === -1 ? sql.length : end + 2
+}
+
+function findStringEnd(sql: string, index: number, quote: string): number {
+  while (index < sql.length) {
+    if (sql[index] === quote) {
+      if (sql[index + 1] === quote) {
+        index += 2
+        continue
+      }
+
+      return index + 1
+    }
+
+    if (sql[index] === '\\') {
+      index += 2
+      continue
+    }
+
+    index += 1
+  }
+
+  return index
+}
+
+function isNumberStart(sql: string, index: number): boolean {
+  const char = sql[index]
+  const next = sql[index + 1]
+
+  return isDigit(char) || (char === '.' && isDigit(next))
+}
+
+function findNumberEnd(sql: string, index: number): number {
+  if (sql[index] === '.') {
+    index += 1
+  }
+
+  while (isDigit(sql[index])) {
+    index += 1
+  }
+
+  if (sql[index] === '.') {
+    index += 1
+
+    while (isDigit(sql[index])) {
+      index += 1
+    }
+  }
+
+  if (sql[index]?.toLowerCase() === 'e') {
+    const exponentStart = index
+    index += 1
+
+    if (sql[index] === '+' || sql[index] === '-') {
+      index += 1
+    }
+
+    if (!isDigit(sql[index])) {
+      return exponentStart
+    }
+
+    while (isDigit(sql[index])) {
+      index += 1
+    }
+  }
+
+  return index
+}
+
+function isDigit(char: string | undefined): boolean {
+  return char != null && char >= '0' && char <= '9'
+}
+
+function isIdentifierStart(char: string | undefined): boolean {
+  return char != null && ((char >= 'A' && char <= 'Z') || (char >= 'a' && char <= 'z') || char === '_')
+}
+
+function isIdentifierPart(char: string | undefined): boolean {
+  return isIdentifierStart(char) || isDigit(char) || char === '$'
+}
+
+function findIdentifierEnd(sql: string, index: number): number {
+  while (isIdentifierPart(sql[index])) {
+    index += 1
+  }
+
+  return index
+}
+
+function isFunctionCall(sql: string, index: number): boolean {
+  while (isWhitespace(sql[index])) {
+    index += 1
+  }
+
+  return sql[index] === '('
+}

--- a/src/colorful-syntax.test.ts
+++ b/src/colorful-syntax.test.ts
@@ -1,0 +1,116 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createQueryEndEvent } from '../test/helpers/events.ts'
+import { colorfulSyntaxFormatter, colorfulSyntaxThemes, colorizeSql } from './colorful-syntax.ts'
+
+const ANSI_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g')
+
+test('colorfulSyntaxThemes extend themes without mutating built-ins', () => {
+  const theme = colorfulSyntaxThemes.dracula.extend({
+    keyword: false,
+    fn: '<f>',
+  })
+
+  assert.equal(theme.keyword, false)
+  assert.equal(theme.fn, '<f>')
+  assert.notEqual(colorfulSyntaxThemes.dracula.keyword, false)
+  assert.notEqual(colorfulSyntaxThemes.dracula.fn, '<f>')
+})
+
+test('colorfulSyntaxThemes are chainable', () => {
+  const theme = colorfulSyntaxThemes.dracula.extend({ keyword: '<k>' }).extend({ keyword: false })
+
+  assert.equal(theme.keyword, false)
+  assert.equal(theme.fn, colorfulSyntaxThemes.dracula.fn)
+})
+
+test('colorfulSyntaxThemes extend method is not enumerable', () => {
+  const theme = colorfulSyntaxThemes.dracula.extend({ keyword: '<k>' })
+
+  assert.equal(Object.keys(theme).includes('extend'), false)
+  assert.equal(Object.keys(colorfulSyntaxThemes.dracula).includes('extend'), false)
+  assert.equal(Object.hasOwn(theme, 'extend'), true)
+})
+
+test('colorizeSql supports partial themes and disabled token colors', () => {
+  const sql = 'select count(*) from users'
+  const colorized = colorizeSql(sql, {
+    theme: {
+      keyword: false,
+      fn: '<f>',
+      clear: '</>',
+    },
+  })
+
+  assert.equal(stripAnsi(colorized.replaceAll('<f>', '').replaceAll('</>', '')), sql)
+  assert.equal(colorized.includes('select</>'), false)
+  assert.equal(colorized.includes('<f>count</>'), true)
+  assert.equal(colorized.includes('\x1b[90m(</>'), true)
+})
+
+test('colorfulSyntaxFormatter colors formatter output', () => {
+  const formatter = colorfulSyntaxFormatter(() => 'select count(*) from users', {
+    theme: {
+      keyword: '<k>',
+      fn: '<f>',
+      clear: '</>',
+    },
+  })
+
+  assert.equal(formatter(createQueryEndEvent()).includes('<k>select</>'), true)
+  assert.equal(formatter(createQueryEndEvent()).includes('<f>count</>'), true)
+})
+
+test('colorizeSql preserves the original text (round-trip)', () => {
+  const inputs = [
+    "select id, count(*) from users where id = 12 and name = 'Ada'",
+    "select 'it''s doubled', 'a\\b escaped', 'unterminated",
+    'select "quoted_ident", 1.5, .5, 1e-5, 1.5e10, 1e, 2.',
+    'select a::int, b >= 1 /* block comment */ from t',
+    'select 1\nfrom t -- trailing',
+    'select * from t /* unterminated block comment',
+    'update t set x = 1 where y >= 2 -- trailing comment',
+    'SELECT DISTINCT a FROM b',
+    'select values(x), count (*)',
+  ]
+
+  for (const sql of inputs) {
+    assert.equal(stripAnsi(colorizeSql(sql)), sql)
+  }
+})
+
+test('colorizeSql colors each token role with the theme', () => {
+  const out = colorizeSql("select count(*) from t where a = 1 and b = 'x' -- note", {
+    theme: {
+      keyword: '<kw>',
+      fn: '<fn>',
+      number: '<n>',
+      string: '<s>',
+      special: '<sp>',
+      bracket: '<br>',
+      comment: '<c>',
+      clear: '</>',
+    },
+  })
+
+  assert.equal(out.includes('<kw>select</>'), true)
+  assert.equal(out.includes('<fn>count</>'), true)
+  assert.equal(out.includes('<br>(</>'), true)
+  assert.equal(out.includes('<sp>*</>'), true)
+  assert.equal(out.includes('<n>1</>'), true)
+  assert.equal(out.includes("<s>'x'</>"), true)
+  assert.equal(out.includes('<c>-- note</>'), true)
+})
+
+test('colorizeSql default theme uses the documented ANSI palette', () => {
+  const out = colorizeSql("select 1, 'x' -- c")
+
+  assert.equal(out.includes('\x1b[35mselect\x1b[0m'), true)
+  assert.equal(out.includes('\x1b[33m1\x1b[0m'), true)
+  assert.equal(out.includes("\x1b[32m'x'\x1b[0m"), true)
+  assert.equal(out.includes('\x1b[2m\x1b[90m-- c\x1b[0m'), true)
+})
+
+function stripAnsi(message: string): string {
+  return message.replace(ANSI_PATTERN, '')
+}

--- a/src/colorful-syntax.ts
+++ b/src/colorful-syntax.ts
@@ -1,0 +1,202 @@
+import { highlightSql } from './colorful-syntax-highlight.ts'
+import type { QueryFormatter } from './types.ts'
+
+/** ANSI color for a SQL token role. `false` disables coloring for that role. */
+export type ColorfulSyntaxColor = string | false
+
+/** Partial ANSI color theme used by `colorful-syntax` helpers. */
+export interface ColorfulSyntaxThemeInput {
+  /** SQL reserved keywords. */
+  keyword?: ColorfulSyntaxColor
+  /** SQL functions. */
+  fn?: ColorfulSyntaxColor
+  /** Numbers. */
+  number?: ColorfulSyntaxColor
+  /** Strings. */
+  string?: ColorfulSyntaxColor
+  /** Special characters. */
+  special?: ColorfulSyntaxColor
+  /** Brackets / parentheses. */
+  bracket?: ColorfulSyntaxColor
+  /** Comments. */
+  comment?: ColorfulSyntaxColor
+  /** Clear code inserted after each colored match. */
+  clear?: string
+}
+
+/**
+ * Complete ANSI color theme used by `colorful-syntax` helpers.
+ *
+ * Exactly `ColorfulSyntaxThemeInput` with every role resolved and frozen, plus
+ * `extend`. Kept in sync with the input via `Required` so the two can't drift.
+ */
+export interface ColorfulSyntaxTheme extends Readonly<Required<ColorfulSyntaxThemeInput>> {
+  /** Return a new theme with these overrides applied. */
+  extend(overrides: ColorfulSyntaxThemeInput): ColorfulSyntaxTheme
+}
+
+/** Options accepted by `colorizeSql` and `colorfulSyntaxFormatter`. */
+export interface ColorfulSyntaxOptions {
+  /** Partial theme merged over `colorfulSyntaxThemes.default`. */
+  theme?: ColorfulSyntaxThemeInput
+}
+
+/**
+ * `default` is a 16-color ANSI theme: it adapts to the terminal's palette and
+ * works everywhere. The named themes below are fixed 24-bit truecolor and need
+ * a truecolor-capable terminal.
+ */
+const DEFAULT_THEME_INPUT = {
+  keyword: '\x1b[35m',
+  fn: '\x1b[36m',
+  number: '\x1b[33m',
+  string: '\x1b[32m',
+  special: '\x1b[90m',
+  bracket: '\x1b[90m',
+  comment: '\x1b[2m\x1b[90m',
+  clear: '\x1b[0m',
+} satisfies Required<ColorfulSyntaxThemeInput>
+
+/** Build a 24-bit truecolor ANSI foreground escape. */
+const rgb = /* @__NO_SIDE_EFFECTS__ */ (r: number, g: number, b: number): string => `\x1b[38;2;${r};${g};${b}m`
+
+/** Built-in SQL syntax color themes. */
+export const colorfulSyntaxThemes = /* @__PURE__ */ Object.freeze({
+  /** Adaptive 16-color ANSI theme. Used when no theme is provided. */
+  default: defineColorfulSyntaxTheme({}),
+  dracula: defineColorfulSyntaxTheme({
+    keyword: rgb(255, 121, 198),
+    fn: rgb(80, 250, 123),
+    number: rgb(189, 147, 249),
+    string: rgb(241, 250, 140),
+    special: rgb(255, 121, 198),
+    bracket: rgb(248, 248, 242),
+    comment: rgb(98, 114, 164),
+  }),
+  nord: defineColorfulSyntaxTheme({
+    keyword: rgb(129, 161, 193),
+    fn: rgb(136, 192, 208),
+    number: rgb(180, 142, 173),
+    string: rgb(163, 190, 140),
+    special: rgb(129, 161, 193),
+    bracket: rgb(236, 239, 244),
+    comment: rgb(76, 86, 106),
+  }),
+  monokai: defineColorfulSyntaxTheme({
+    keyword: rgb(249, 38, 114),
+    fn: rgb(166, 226, 46),
+    number: rgb(174, 129, 255),
+    string: rgb(230, 219, 116),
+    special: rgb(249, 38, 114),
+    bracket: rgb(248, 248, 242),
+    comment: rgb(117, 113, 94),
+  }),
+  oneDark: defineColorfulSyntaxTheme({
+    keyword: rgb(198, 120, 221),
+    fn: rgb(97, 175, 239),
+    number: rgb(209, 154, 102),
+    string: rgb(152, 195, 121),
+    special: rgb(86, 182, 194),
+    bracket: rgb(171, 178, 191),
+    comment: rgb(92, 99, 112),
+  }),
+  solarizedDark: defineColorfulSyntaxTheme({
+    keyword: rgb(133, 153, 0),
+    fn: rgb(38, 139, 210),
+    number: rgb(211, 54, 130),
+    string: rgb(42, 161, 152),
+    special: rgb(131, 148, 150),
+    bracket: rgb(131, 148, 150),
+    comment: rgb(88, 110, 117),
+  }),
+  tokyoNight: defineColorfulSyntaxTheme({
+    keyword: rgb(187, 154, 247),
+    fn: rgb(122, 162, 247),
+    number: rgb(255, 158, 100),
+    string: rgb(158, 206, 106),
+    special: rgb(137, 221, 255),
+    bracket: rgb(192, 202, 245),
+    comment: rgb(86, 95, 137),
+  }),
+  catppuccinMocha: defineColorfulSyntaxTheme({
+    keyword: rgb(203, 166, 247),
+    fn: rgb(137, 180, 250),
+    number: rgb(250, 179, 135),
+    string: rgb(166, 227, 161),
+    special: rgb(137, 220, 235),
+    bracket: rgb(186, 194, 222),
+    comment: rgb(108, 112, 134),
+  }),
+  solarizedLight: defineColorfulSyntaxTheme({
+    keyword: rgb(133, 153, 0),
+    fn: rgb(38, 139, 210),
+    number: rgb(211, 54, 130),
+    string: rgb(42, 161, 152),
+    special: rgb(101, 123, 131),
+    bracket: rgb(101, 123, 131),
+    comment: rgb(147, 161, 161),
+  }),
+  githubLight: defineColorfulSyntaxTheme({
+    keyword: rgb(207, 34, 46),
+    fn: rgb(130, 80, 223),
+    number: rgb(5, 80, 174),
+    string: rgb(10, 48, 105),
+    special: rgb(87, 96, 106),
+    bracket: rgb(36, 41, 47),
+    comment: rgb(110, 119, 129),
+  }),
+  oneLight: defineColorfulSyntaxTheme({
+    keyword: rgb(166, 38, 164),
+    fn: rgb(64, 120, 242),
+    number: rgb(152, 104, 1),
+    string: rgb(80, 161, 79),
+    special: rgb(160, 161, 167),
+    bracket: rgb(56, 58, 66),
+    comment: rgb(160, 161, 167),
+  }),
+  catppuccinLatte: defineColorfulSyntaxTheme({
+    keyword: rgb(136, 57, 239),
+    fn: rgb(30, 102, 245),
+    number: rgb(254, 100, 11),
+    string: rgb(64, 160, 43),
+    special: rgb(108, 111, 133),
+    bracket: rgb(108, 111, 133),
+    comment: rgb(140, 143, 161),
+  }),
+})
+
+/** Create a query formatter that syntax-colors another query formatter's SQL output. */
+export function colorfulSyntaxFormatter(
+  formatter: QueryFormatter,
+  options: ColorfulSyntaxOptions = {},
+): QueryFormatter {
+  const theme = defineColorfulSyntaxTheme(options.theme ?? {})
+
+  return (query) => highlightSql(formatter(query), theme)
+}
+
+/** Syntax-color a SQL string with ANSI colors. */
+export function colorizeSql(sql: string, options: ColorfulSyntaxOptions = {}): string {
+  return highlightSql(sql, defineColorfulSyntaxTheme(options.theme ?? {}))
+}
+
+/* @__NO_SIDE_EFFECTS__ */ function defineColorfulSyntaxTheme(input: ColorfulSyntaxThemeInput): ColorfulSyntaxTheme {
+  const theme: ColorfulSyntaxTheme = {
+    keyword: input.keyword ?? DEFAULT_THEME_INPUT.keyword,
+    fn: input.fn ?? DEFAULT_THEME_INPUT.fn,
+    number: input.number ?? DEFAULT_THEME_INPUT.number,
+    string: input.string ?? DEFAULT_THEME_INPUT.string,
+    special: input.special ?? DEFAULT_THEME_INPUT.special,
+    bracket: input.bracket ?? DEFAULT_THEME_INPUT.bracket,
+    comment: input.comment ?? DEFAULT_THEME_INPUT.comment,
+    clear: input.clear ?? DEFAULT_THEME_INPUT.clear,
+    extend(overrides: ColorfulSyntaxThemeInput) {
+      return defineColorfulSyntaxTheme({ ...theme, ...overrides })
+    },
+  }
+
+  // `extend` is a helper, not a themable color: keep it off enumeration and spreads.
+  Object.defineProperty(theme, 'extend', { enumerable: false })
+
+  return Object.freeze(theme)
+}

--- a/src/colorful.ts
+++ b/src/colorful.ts
@@ -1,2 +1,9 @@
+export type { ColorfulLoggerOptions } from './colorful-logger.ts'
 export { colorfulLogger } from './colorful-logger.ts'
-export type { ColorfulLoggerOptions } from './types.ts'
+export type {
+  ColorfulSyntaxColor,
+  ColorfulSyntaxOptions,
+  ColorfulSyntaxTheme,
+  ColorfulSyntaxThemeInput,
+} from './colorful-syntax.ts'
+export { colorfulSyntaxFormatter, colorfulSyntaxThemes, colorizeSql } from './colorful-syntax.ts'

--- a/src/default-logger.ts
+++ b/src/default-logger.ts
@@ -1,6 +1,6 @@
-import { defaultQueryFormatter } from './formatter.ts'
 import { resolveMessageWriter } from './message-writer.ts'
-import type { DefaultLoggerOptions, Logger, QueryFormatter } from './types.ts'
+import { resolveStringFormatter } from './resolve-formatter.ts'
+import type { DefaultLoggerOptions, Logger } from './types.ts'
 
 /**
  * Create the built-in dependency-free string logger.
@@ -23,7 +23,7 @@ import type { DefaultLoggerOptions, Logger, QueryFormatter } from './types.ts'
  */
 export function defaultLogger(options: DefaultLoggerOptions = {}): Logger {
   const write = resolveMessageWriter(options.write)
-  const formatter = resolveFormatter(options)
+  const formatter = resolveStringFormatter(options)
 
   return {
     onEnd(event) {
@@ -33,16 +33,4 @@ export function defaultLogger(options: DefaultLoggerOptions = {}): Logger {
       write(`SQL ERROR (${event.durationMs.toFixed(3)} ms) ${formatter(event)}`)
     },
   }
-}
-
-function resolveFormatter(options: DefaultLoggerOptions): QueryFormatter {
-  if (options.formatter) {
-    if ('bindings' in options) {
-      console.warn('knex-tiny-logger: "bindings" is ignored when "formatter" is provided.')
-    }
-
-    return options.formatter
-  }
-
-  return defaultQueryFormatter({ bindings: options.bindings })
 }

--- a/src/resolve-formatter.ts
+++ b/src/resolve-formatter.ts
@@ -1,0 +1,21 @@
+import { defaultQueryFormatter } from './formatter.ts'
+import type { QueryFormatter, StringLoggerOptions } from './types.ts'
+
+/**
+ * Resolve the SQL formatter for a string logger.
+ *
+ * A custom `formatter` wins and makes `bindings` irrelevant, so passing both
+ * warns. Otherwise the built-in formatter is used with the requested
+ * `bindings` behavior.
+ */
+export function resolveStringFormatter(options: StringLoggerOptions): QueryFormatter {
+  if (options.formatter) {
+    if ('bindings' in options) {
+      console.warn('knex-tiny-logger: "bindings" is ignored when "formatter" is provided.')
+    }
+
+    return options.formatter
+  }
+
+  return defaultQueryFormatter({ bindings: options.bindings })
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,8 +139,6 @@ export type StringLoggerOptions = StringLoggerBaseOptions &
 
 /** Options accepted by `defaultLogger`. */
 export type DefaultLoggerOptions = StringLoggerOptions
-/** Options accepted by `colorfulLogger`; same formatting options as `defaultLogger`. */
-export type ColorfulLoggerOptions = StringLoggerOptions
 
 /** Options for `createTracer`. */
 export interface CreateTracerOptions extends TracerHooks {

--- a/test/runtime/bun/runtime.test.ts
+++ b/test/runtime/bun/runtime.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'bun:test'
 import knexTinyLogger, { defaultLogger } from 'knex-tiny-logger'
+import { colorfulLogger, colorfulSyntaxThemes } from 'knex-tiny-logger/colorful'
 import { pinoLogger } from 'knex-tiny-logger/pino'
 import { createTracer } from 'knex-tiny-logger/tracer'
 
@@ -67,6 +68,7 @@ test('subpath adapters work in the Bun runtime', () => {
   const knex = new FakeKnex()
   const entries: Record<string, unknown>[] = []
   const ends: unknown[] = []
+  const messages: string[] = []
 
   createTracer(knex as never, {
     onEnd(query) {
@@ -81,6 +83,19 @@ test('subpath adapters work in the Bun runtime', () => {
       },
       error(entry) {
         entries.push(entry)
+      },
+    }),
+  })
+
+  knexTinyLogger(knex as never, {
+    logger: colorfulLogger({
+      highlight: true,
+      theme: colorfulSyntaxThemes.default,
+      formatter(query) {
+        return query.sql
+      },
+      write(message) {
+        messages.push(message)
       },
     }),
   })
@@ -101,4 +116,6 @@ test('subpath adapters work in the Bun runtime', () => {
     bindings: [2],
   })
   expect(typeof entries[0]?.durationMs).toBe('number')
+  expect(messages).toHaveLength(1)
+  expect(messages[0]).toContain('\x1b[35mselect\x1b[0m')
 })

--- a/test/runtime/node/runtime.test.mjs
+++ b/test/runtime/node/runtime.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 import { createRequire } from 'node:module'
 import { test } from 'node:test'
 import knexTinyLogger, { defaultLogger, defaultQueryFormatter } from 'knex-tiny-logger'
-import { colorfulLogger } from 'knex-tiny-logger/colorful'
+import { colorfulLogger, colorfulSyntaxFormatter, colorfulSyntaxThemes, colorizeSql } from 'knex-tiny-logger/colorful'
 import { pinoLogger } from 'knex-tiny-logger/pino'
 import { createTracer } from 'knex-tiny-logger/tracer'
 
@@ -76,6 +76,9 @@ test('esm subpath adapters work in Node.js', () => {
   const ends = []
 
   assert.equal(typeof colorfulLogger, 'function')
+  assert.equal(typeof colorfulSyntaxFormatter, 'function')
+  assert.equal(typeof colorfulSyntaxThemes.dracula.extend, 'function')
+  assert.equal(typeof colorizeSql, 'function')
   assert.equal(typeof pinoLogger, 'function')
   assert.equal(typeof createTracer, 'function')
 
@@ -112,9 +115,46 @@ test('esm subpath adapters work in Node.js', () => {
   assert.equal(typeof entries[0].durationMs, 'number')
 })
 
+test('esm colorful highlight works in Node.js', () => {
+  const knex = new FakeKnex()
+  const messages = []
+
+  knexTinyLogger(knex, {
+    logger: colorfulLogger({
+      highlight: true,
+      theme: colorfulSyntaxThemes.default.extend({ keyword: false }),
+      formatter(query) {
+        return query.sql
+      },
+      write(message) {
+        messages.push(message)
+      },
+    }),
+  })
+
+  const query = {
+    __knexQueryUid: 'query-3',
+    sql: 'select count(*) from users',
+    bindings: [],
+  }
+
+  knex.emit('query', query)
+  knex.emit('query-response', [{ value: 1 }], query)
+
+  assert.equal(messages.length, 1)
+  assert.match(messages[0], /SQL \(/)
+  assert.equal(messages[0].includes('select'), true)
+  assert.equal(messages[0].includes('\x1b[36mcount\x1b[0m'), true)
+})
+
 test('commonjs package entrypoint works in Node.js', () => {
   const knexTinyLoggerCjs = require('knex-tiny-logger')
-  const { colorfulLogger } = require('knex-tiny-logger/colorful')
+  const {
+    colorfulLogger,
+    colorfulSyntaxFormatter,
+    colorfulSyntaxThemes,
+    colorizeSql,
+  } = require('knex-tiny-logger/colorful')
   const { pinoLogger } = require('knex-tiny-logger/pino')
   const { createTracer } = require('knex-tiny-logger/tracer')
 
@@ -123,6 +163,9 @@ test('commonjs package entrypoint works in Node.js', () => {
   assert.equal(knexTinyLoggerCjs.createTracer, undefined)
   assert.equal(typeof knexTinyLoggerCjs.defaultLogger, 'function')
   assert.equal(typeof colorfulLogger, 'function')
+  assert.equal(typeof colorfulSyntaxFormatter, 'function')
+  assert.equal(typeof colorfulSyntaxThemes.dracula.extend, 'function')
+  assert.equal(typeof colorizeSql, 'function')
   assert.equal(typeof pinoLogger, 'function')
   assert.equal(typeof createTracer, 'function')
 })

--- a/test/types/package.test.cts
+++ b/test/types/package.test.cts
@@ -7,6 +7,12 @@ import type {
   QueryFormatter,
   SimpleLogger,
 } from 'knex-tiny-logger'
+import type {
+  ColorfulLoggerOptions,
+  ColorfulSyntaxColor,
+  ColorfulSyntaxTheme,
+  ColorfulSyntaxThemeInput,
+} from 'knex-tiny-logger/colorful'
 import type { PinoLikeLogger } from 'knex-tiny-logger/pino'
 import type { TracerErrorEvent } from 'knex-tiny-logger/tracer'
 
@@ -16,13 +22,22 @@ import pinoFactory = require('pino')
 import pinoAdapter = require('knex-tiny-logger/pino')
 import tracer = require('knex-tiny-logger/tracer')
 
-const { colorfulLogger } = colorful
+const { colorfulLogger, colorfulSyntaxFormatter, colorfulSyntaxThemes, colorizeSql } = colorful
 const { pinoLogger } = pinoAdapter
 const { createTracer } = tracer
 
 declare const knex: Knex
 declare const pinoLike: PinoLikeLogger
 declare const messageWriterTarget: MessageWriterTarget
+
+const syntaxColor: ColorfulSyntaxColor = false
+const syntaxThemeInput: ColorfulSyntaxThemeInput = {
+  keyword: '\x1b[35m',
+  fn: syntaxColor,
+}
+const syntaxTheme: ColorfulSyntaxTheme = colorfulSyntaxThemes.dracula.extend(syntaxThemeInput).extend({
+  keyword: false,
+})
 
 // Root API
 knexTinyLogger(knex) satisfies Knex
@@ -40,6 +55,38 @@ knexTinyLogger.createTracer
 knexTinyLogger.defaultLogger() satisfies Logger
 knexTinyLogger.defaultLogger({ write: messageWriterTarget }) satisfies Logger
 colorfulLogger() satisfies Logger
+colorfulLogger({ highlight: true }) satisfies Logger
+colorfulLogger({
+  highlight: true,
+  theme: syntaxTheme,
+} satisfies ColorfulLoggerOptions) satisfies Logger
+
+// @ts-expect-error `theme` applies only in highlight mode.
+colorfulLogger({ theme: syntaxTheme })
+
+colorfulLogger({
+  // @ts-expect-error the theme option takes objects, not theme names.
+  theme: 'light',
+})
+
+colorfulLogger({
+  // @ts-expect-error the theme option takes objects, not a separate colors option.
+  colors: {
+    keyword: '\x1b[35m',
+  },
+})
+
+colorfulLogger({
+  theme: {
+    // @ts-expect-error use `fn` for SQL functions.
+    function: '\x1b[31m',
+  },
+})
+
+colorizeSql('select 1', { theme: syntaxTheme }) satisfies string
+colorfulSyntaxFormatter(knexTinyLogger.defaultQueryFormatter(), {
+  theme: colorfulSyntaxThemes.solarizedLight.extend({ fn: false }),
+}) satisfies QueryFormatter
 
 // Formatter
 knexTinyLogger.defaultQueryFormatter({

--- a/test/types/package.test.mts
+++ b/test/types/package.test.mts
@@ -15,7 +15,13 @@ import knexTinyLogger, {
   type SimpleLogger,
   type StringLoggerOptions,
 } from 'knex-tiny-logger'
-import { colorfulLogger } from 'knex-tiny-logger/colorful'
+import type {
+  ColorfulLoggerOptions,
+  ColorfulSyntaxColor,
+  ColorfulSyntaxTheme,
+  ColorfulSyntaxThemeInput,
+} from 'knex-tiny-logger/colorful'
+import { colorfulLogger, colorfulSyntaxFormatter, colorfulSyntaxThemes, colorizeSql } from 'knex-tiny-logger/colorful'
 import type { PinoLikeLogger, PinoLoggerOptions } from 'knex-tiny-logger/pino'
 import { pinoLogger } from 'knex-tiny-logger/pino'
 import type { TracerErrorEvent, TracerQueryEndEvent } from 'knex-tiny-logger/tracer'
@@ -84,6 +90,29 @@ const pinoOptions: PinoLoggerOptions = {
   errorMessage: 'SQL query failed',
 }
 
+const syntaxColor: ColorfulSyntaxColor = false
+
+const syntaxThemeInput: ColorfulSyntaxThemeInput = {
+  keyword: '\x1b[35m',
+  fn: syntaxColor,
+}
+
+const syntaxTheme: ColorfulSyntaxTheme = colorfulSyntaxThemes.dracula.extend({
+  keyword: false,
+  fn: '\x1b[31m',
+  number: '\x1b[32m',
+  string: '\x1b[32m',
+  special: '\x1b[33m',
+  bracket: '\x1b[33m',
+  comment: '\x1b[2m\x1b[90m',
+  clear: '\x1b[0m',
+})
+
+const syntaxOptions: ColorfulLoggerOptions = {
+  highlight: true,
+  theme: syntaxTheme,
+}
+
 // Root API
 knexTinyLogger(knex)
 knexTinyLogger(knex, options) satisfies Knex
@@ -137,6 +166,50 @@ defaultLogger({
 colorfulLogger() satisfies Logger
 colorfulLogger({ write: simpleLogger }) satisfies Logger
 colorfulLogger({ write: messageWriterTarget }) satisfies Logger
+colorfulLogger({ highlight: true }) satisfies Logger
+colorfulLogger({ highlight: true, theme: syntaxThemeInput }) satisfies Logger
+colorfulLogger(syntaxOptions) satisfies Logger
+colorfulLogger({ highlight: true, theme: syntaxThemeInput, write: messageWriter }) satisfies Logger
+
+// @ts-expect-error `theme` applies only in highlight mode.
+colorfulLogger({ theme: syntaxThemeInput })
+
+colorfulLogger({
+  highlight: true,
+  formatter(event) {
+    event.sql satisfies string
+
+    return event.sql
+  },
+  theme: {
+    clear: '\x1b[0m',
+  },
+}) satisfies Logger
+
+colorfulLogger({
+  // @ts-expect-error the theme option takes objects, not theme names.
+  theme: 'dark',
+})
+
+colorfulLogger({
+  // @ts-expect-error the theme option takes objects, not a separate colors option.
+  colors: {
+    keyword: '\x1b[34m',
+  },
+})
+
+colorfulLogger({
+  theme: {
+    // @ts-expect-error use `fn` for SQL functions.
+    function: '\x1b[31m',
+  },
+})
+
+colorizeSql('select 1') satisfies string
+colorizeSql('select 1', { theme: colorfulSyntaxThemes.dracula.extend({ keyword: false }) }) satisfies string
+colorfulSyntaxFormatter(defaultQueryFormatter(), {
+  theme: colorfulSyntaxThemes.solarizedLight.extend({ fn: false }).extend({ keyword: '\x1b[35m' }),
+}) satisfies QueryFormatter
 
 // @ts-expect-error bindings belongs only to the default string formatter path.
 const _invalidLoggerOptions: StringLoggerOptions = {


### PR DESCRIPTION
## Summary

Resolves #5.

SQL syntax highlighting for the colorful logger — the feature originally requested in #5.

That issue was closed in April as "not planned for the built-in logger": the plan was to keep the core tiny and push highlighting into userland formatters. This PR delivers it in-package instead, without adding runtime dependencies and without breaking the "keep it tiny" rule — the themes tree-shake away for consumers that don't use them.

The existing `colorfulLogger` gains an opt-in `highlight` flag:

- `colorfulLogger()` — tints the whole line by query state (default).
- `colorfulLogger({ highlight: true, theme })` — syntax-highlights the SQL body; the label still carries the query state.
- `theme` requires `highlight: true` at the type level (discriminated union, mirroring `bindings`/`formatter`); a runtime `console.warn` still guards untyped callers.

The syntax helpers (`colorfulSyntaxThemes`, `colorfulSyntaxFormatter`, `colorizeSql`) are exported from the existing `knex-tiny-logger/colorful` subpath, so highlighting is reusable in custom formatters too.

No API/signature break. The one behavioral change to existing output: the `colorfulLogger` label is now colored by query state and reads `SQL ERROR` on failure (was a fixed magenta `SQL` prefix).

## Themes

`colorfulSyntaxThemes.default` is an adaptive 16-color ANSI palette used when no theme is given (number/string and operator/bracket get distinct colors). The named themes are fixed 24-bit truecolor ports of popular editor schemes, each keeping number and string distinct:

- dark: `dracula`, `nord`, `monokai`, `oneDark`, `solarizedDark`, `tokyoNight`, `catppuccinMocha`
- light: `solarizedLight`, `githubLight`, `oneLight`, `catppuccinLatte`

Themes are extendable (`.extend({ keyword: false, fn: '\x1b[31m' })`), and the same coloring is reusable in custom formatters via `colorfulSyntaxFormatter`.

## Verification

- `pnpm run check` green: build, typecheck, type tests (`.cts`/`.mts`), attw (4 subpaths 🟢), lint, 53 unit + 7 integration
- tree-shaking verified: a tint-only `colorfulLogger` consumer bundles none of the themes (`@__NO_SIDE_EFFECTS__` on `rgb`/`defineColorfulSyntaxTheme`)
- runtime: node 4/4, bun 2/2

Also migrates the biome config to the 2.5 preset (separate `chore` commit).


